### PR TITLE
Remove outdated fails_with directive

### DIFF
--- a/cilkrts.rb
+++ b/cilkrts.rb
@@ -16,13 +16,6 @@ class Cilkrts < Formula
   depends_on "tapir"
   depends_on "cmake" => :build
 
-  # requires gcc >= 4.8
-  fails_with :gcc_4_0
-  fails_with :gcc
-  ("4.3".."4.7").each do |n|
-    fails_with :gcc => n
-  end
-
   def ver
     return "1.0"
   end

--- a/tapir.rb
+++ b/tapir.rb
@@ -60,13 +60,6 @@ class Tapir < Formula
     depends_on "swig" if MacOS.version >= :lion
   end
 
-  # According to the official llvm readme, GCC 4.7+ is required
-  fails_with :gcc_4_0
-  fails_with :gcc
-  ("4.3".."4.6").each do |n|
-    fails_with :gcc => n
-  end
-
   def build_libcxx?
     build.with?("libcxx") || !MacOS::CLT.installed?
   end


### PR DESCRIPTION
On current versions of homebrew, installing Tapir and CilkRTS from these formula fail with error message:

```
$ brew install wsmoses/tools/cilkrts
==> Tapping wsmoses/tools
Cloning into '/usr/local/Homebrew/Library/Taps/wsmoses/homebrew-tools'...
remote: Enumerating objects: 4, done.
remote: Counting objects: 100% (4/4), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 4 (delta 0), reused 2 (delta 0), pack-reused 0
Unpacking objects: 100% (4/4), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/wsmoses/homebrew-tools/cilkrts.rb
Calling fails_with :gcc_4_0 is disabled! There is no replacement.
Please report this to the wsmoses/tools tap:
  /usr/local/Homebrew/Library/Taps/wsmoses/homebrew-tools/cilkrts.rb:20
```

They must have deprecated `fails_with` for all of the :gcc versions. This patch removes these directives - installation succeeds without them.

(Probably because I don't have gcc 4 installed)